### PR TITLE
Replace option "position" with "placement" to match the source

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ You can also don't touch the `tooltip.css` and do the same thing using `v-toolti
         v-tooltip="{
                     global: true,
                     theme: {
-                        position: 'bottom',
+                        placement: 'bottom',
                         width: 'fit-content',
                         padding: '2rem',
                     },
@@ -154,7 +154,7 @@ This will affect every tooltip in the app, because it changes the CSS variables 
 -   Options (all of them are non-mandatory):
     -   text - text inside created tooltip
     -   theme - takes care of styling tooltips of the element and its children. Accepted properties:
-        -   position - `top (default), bottom, left, right`: placement of the tooltip relative to the element its called on
+        -   placement - `top (default), bottom, left, right`: placement of the tooltip relative to the element its called on
         -   width - default `max-content`
         -   background-color - default `#000000`
         -   color - default `#ffffff`


### PR DESCRIPTION
This fixes the mistakenly documented `position` option. Changed the documentation instead of the source since the word `placement` makes more sense for the purpose.