### PR TITLE
Fix blurry text

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ You can also don't touch the `tooltip.css` and do the same thing using `v-toolti
         v-tooltip="{
                     global: true,
                     theme: {
-                        position: 'bottom',
+                        placement: 'bottom',
                         width: 'fit-content',
                         padding: '2rem',
                     },
@@ -154,7 +154,7 @@ This will affect every tooltip in the app, because it changes the CSS variables 
 -   Options (all of them are non-mandatory):
     -   text - text inside created tooltip
     -   theme - takes care of styling tooltips of the element and its children. Accepted properties:
-        -   position - `top (default), bottom, left, right`: placement of the tooltip relative to the element its called on
+        -   placement - `top (default), bottom, left, right`: placement of the tooltip relative to the element its called on
         -   width - default `max-content`
         -   background-color - default `#000000`
         -   color - default `#ffffff`

--- a/tooltip.css
+++ b/tooltip.css
@@ -1,7 +1,7 @@
 :root {
     --v-tooltip-left: 50%;
     --v-tooltip-top: 0%;
-    --v-tooltip-translate3d: translate3d(-50%, -110%, 0);
+    --v-tooltip-translate: translate(-50%, -110%);
     --v-tooltip-width: max-content;
     --v-tooltip-background-color: #000000;
     --v-tooltip-color: #ffffff;
@@ -22,7 +22,7 @@
     position: absolute;
     left: var(--v-tooltip-left);
     top: var(--v-tooltip-top);
-    transform: var(--v-tooltip-translate3d);
+    transform: var(--v-tooltip-translate);
     width: var(--v-tooltip-width);
     background-color: var(--v-tooltip-background-color);
     color: var(--v-tooltip-color);

--- a/tooltip.js
+++ b/tooltip.js
@@ -25,8 +25,8 @@ export default {
                                     "0%"
                                 );
                                 targetEl.style.setProperty(
-                                    "--v-tooltip-translate3d",
-                                    "translate3d(-50%, -110%, 0)"
+                                    "--v-tooltip-translate",
+                                    "translate(-50%, -110%)"
                                 );
                                 break;
                             case "bottom":
@@ -39,8 +39,8 @@ export default {
                                     "100%"
                                 );
                                 targetEl.style.setProperty(
-                                    "--v-tooltip-translate3d",
-                                    "translate3d(-50%, 10%, 0)"
+                                    "--v-tooltip-translate",
+                                    "translate(-50%, 10%)"
                                 );
                                 break;
                             case "left":
@@ -53,8 +53,8 @@ export default {
                                     "50%"
                                 );
                                 targetEl.style.setProperty(
-                                    "--v-tooltip-translate3d",
-                                    "translate3d(-110%, -50%, 0)"
+                                    "--v-tooltip-translate",
+                                    "translate(-110%, -50%)"
                                 );
                                 break;
                             case "right":
@@ -67,8 +67,8 @@ export default {
                                     "50%"
                                 );
                                 targetEl.style.setProperty(
-                                    "--v-tooltip-translate3d",
-                                    "translate3d(10%, -50%, 0)"
+                                    "--v-tooltip-translate",
+                                    "translate(10%, -50%)"
                                 );
                                 break;
                             default:


### PR DESCRIPTION
This PR fixes blurry text on Webkit and Blink caused by the usage of `translate3d`. It's replaced with `translate` which does the job in same manner and performance.

_NOTE:_
Please merge #1 before this since I accidentally included that changes in this branch.